### PR TITLE
release 202007-1

### DIFF
--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -37,25 +37,32 @@ class CartItem < ApplicationRecord
   #   @_barcode_count ||= barcodes.length
   # end
 
+  zombie :product_option
+
+  delegate :page_title, to: :zombie_product_option
+  delegate :title, to: :zombie_product_option, prefix: :option # option_title
+  delegate :name, to: :zombie_product_option, prefix: :option # option_name
+  delegate :thumbnail, to: :product_page, prefix: :page
+
   # 단위 정가 & 합계
-  delegate :base_price, to: :product_option
+  delegate :base_price, to: :zombie_product_option
   def base_price_sum
-    option_count * product_option.base_price
+    option_count * (captured ? captured_base_price : base_price)
   end
 
   # 구성 품목 수량 & 합계
   # A.K.A. EA (e.g. 10 EA)
   # 몇 개의 ProductItem 재고단위로 구성되었는가.
-  delegate :unit_count, to: :product_option
+  delegate :unit_count, to: :zombie_product_option
   def unit_count_sum
     option_count * unit_count
   end
 
   # 단위 변동가 & 합계
   # 일반적인 경우, 음수값을 가짐
-  delegate :price_change, to: :product_option
+  delegate :price_change, to: :zombie_product_option
   def price_change_sum
-    option_count * price_change
+    option_count * (captured ? captured_price_change : price_change)
   end
 
   # 합산 가격
@@ -122,6 +129,23 @@ class CartItem < ApplicationRecord
 
   def self.item_count(product_item)
     all.map { |cart_item| cart_item.item_count(product_item) }.sum
+  end
+
+  def capture_price_fields!
+    capture_price_fields
+    save!
+  end
+
+  def capture_price_fields
+    po = zombie_product_option
+    tap do |item|
+      item.captured_base_price = po.base_price
+      item.captured_discount_price = po.discount_price
+      item.captured_additional_price = po.additional_price
+      item.captured_price_change = po.price_change
+      item.captured_retail_price = po.retail_price
+      item.captured = true
+    end
   end
 
   # def _barcode_count

--- a/app/models/order_info.rb
+++ b/app/models/order_info.rb
@@ -19,7 +19,6 @@ class OrderInfo < NationRecord
 
   delegate :order_status, to: :cart
   # alias_attribute :status, :order_status
-  alias_attribute :ordered_at, :created_at
   delegate :delivery_amount, to: :ship_info, allow_nil: true
   delegate :amount, to: :payment, allow_nil: true
   delegate :pay_method, to: :payment, allow_nil: true

--- a/db/data/20200624093947_set_ordered_at_to_order_info.rb
+++ b/db/data/20200624093947_set_ordered_at_to_order_info.rb
@@ -1,0 +1,11 @@
+class SetOrderedAtToOrderInfo < ActiveRecord::Migration[6.0]
+  def up
+    ApplicationRecord.country_context_with 'global' do
+      OrderInfo.update_all('ordered_at=created_at')
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20200630093017_set_captured_prices_to_ordered_cart_items.rb
+++ b/db/data/20200630093017_set_captured_prices_to_ordered_cart_items.rb
@@ -1,0 +1,23 @@
+class SetCapturedPricesToOrderedCartItems < ActiveRecord::Migration[6.0]
+  def up
+    ApplicationRecord.country_context_with 'global' do
+      OrderInfo.all.each do |order|
+        order.items.each do |cart_item|
+          timely_option = cart_item.product_option&.version_at(order.created_at) || ProductOption.zombie_find(cart_item.product_option_id)&.version_at(order.created_at)
+          cart_item.update(
+            captured_base_price: timely_option.base_price,
+            captured_discount_price: timely_option.discount_price,
+            captured_additional_price: timely_option.additional_price,
+            captured_retail_price: timely_option.retail_price,
+            captured_price_change: timely_option.price_change,
+            captured: true
+          ) if timely_option
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20200630092452_rename_captured_price_columns_and_add_column_captured.rb
+++ b/db/migrate/20200630092452_rename_captured_price_columns_and_add_column_captured.rb
@@ -1,0 +1,17 @@
+class RenameCapturedPriceColumnsAndAddColumnCaptured < ActiveRecord::Migration[6.0]
+  def change
+    add_prefix_to_captured_price_columns
+
+    add_column :cart_items, :captured, :boolean, null: false, default: false
+  end
+
+  private
+
+  def add_prefix_to_captured_price_columns
+    rename_column :cart_items, :base_price, :captured_base_price
+    rename_column :cart_items, :discount_price, :captured_discount_price
+    rename_column :cart_items, :additional_price, :captured_additional_price
+    rename_column :cart_items, :retail_price, :captured_retail_price
+    rename_column :cart_items, :price_change, :captured_price_change
+  end
+end

--- a/db/migrate/cart_item/20200630080410_add_columns_to_cart_items_for_captured_prices.rb
+++ b/db/migrate/cart_item/20200630080410_add_columns_to_cart_items_for_captured_prices.rb
@@ -1,0 +1,9 @@
+class AddColumnsToCartItemsForCapturedPrices < ActiveRecord::Migration[6.0]
+  def change
+    add_column :cart_items, :base_price, :integer, null: false, default: 0
+    add_column :cart_items, :discount_price, :integer, null: false, default: 0
+    add_column :cart_items, :additional_price, :integer, null: false, default: 0
+    add_column :cart_items, :retail_price, :integer, null: false, default: 0
+    add_column :cart_items, :price_change, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/order_info/20200624093424_add_column_ordered_at_to_order_info.rb
+++ b/db/migrate/order_info/20200624093424_add_column_ordered_at_to_order_info.rb
@@ -1,0 +1,5 @@
+class AddColumnOrderedAtToOrderInfo < ActiveRecord::Migration[6.0]
+  def change
+    add_column :order_infos, :ordered_at, :datetime
+  end
+end


### PR DESCRIPTION
# Release Note

## 주요 변경 사항
- 외부 채널 주문 입력 시, ordered_at을 설정할 수 있고, 주문 삭제가 가능합니다.(#54)
- 통계 콘솔이 aws의 QuickSight로 대체됩니다.(#53)

## new features
- OrderInfo에 ordered_at 컬럼이 추가되었습니다.
- QuickSight를 도입하며, 모델 버저닝 젬의 의존도를 줄임과 동시에 통계에 활용될 수 있는 captured price 컬럼들이 추가되었습니다.
  - CartItem에 captured, captured_base_price, captured_retail_price, captured_discount_price, captured_additional_price, captured_price_change가 추가되었습니다.