### PR TITLE
기능: Adatper Factory 생성

### DIFF
--- a/app/adapters/external_channel/adapter_factory.rb
+++ b/app/adapters/external_channel/adapter_factory.rb
@@ -1,0 +1,14 @@
+module ExternalChannel
+  class AdapterFactory
+    def initialize(channel_name)
+      case channel_name
+      when 'haravan'
+        ExternalChannel::HaravanAdapter.new
+      when 'tiki'
+        ExternalChannel::TikiAdapter.new
+      else
+        raise NotImplementedError('Requested Data Is Not Supported!')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- 추가 이유
1. adapter 사용자의 입장에서 같은 로직을 담당하는 함수가 채널 별로 존재하지 않아도 된다.