### PR TITLE
기능: 외부 채널 validator의 validate_presence_of에 exception 추가

### DIFF
--- a/app/services/external_channel/base_validator.rb
+++ b/app/services/external_channel/base_validator.rb
@@ -21,9 +21,11 @@ module ExternalChannel
       data.keys.sort == keys.sort
     end
 
-    def validate_presence_of(data)
-      keys.all? { |key| !data[key].blank? }
+    def validate_presence_of(data, exception = [])
+      keys.all? do |key|
+        next if exception.include? key
+        !data[key].blank?
+      end
     end
-
   end
 end

--- a/app/services/external_channel/order/saver.rb
+++ b/app/services/external_channel/order/saver.rb
@@ -49,6 +49,7 @@ module ExternalChannel
           order_number: order[:order_number],
           cancelled_status: order[:cancelled_status],
           external_channel_order_id: order[:id],
+          shipping_status: order[:shipping_status]
         }
       end
 

--- a/app/services/external_channel/order/validator.rb
+++ b/app/services/external_channel/order/validator.rb
@@ -3,7 +3,7 @@ module ExternalChannel
     class Validator < BaseValidator
 
       def initialize
-        @keys = [:id, :order_number, :paid_at, :order_status, :pay_method, :channel, :ordered_at, :billing_amount, :ship_fee, :variant_ids, :cancelled_status, :shipping_status, ]
+        @keys = [:id, :order_number, :paid_at, :order_status, :pay_method, :channel, :ordered_at, :billing_amount, :ship_fee, :variant_ids, :cancelled_status, :shipping_status ]
       end
 
       def valid_all?(orders)
@@ -13,17 +13,8 @@ module ExternalChannel
       end
 
       def valid?(order)
-        validate_presence_of(order)
+        validate_presence_of(order, [:paid_at, :cancelled_status, :shipping_status])
         has_only_allowed(order)
-      end
-
-      protected
-
-      @override
-      def has_only_allowed(data)
-        data[:paid_at] = 'empty' if data[:paid_at].nil?
-        data[:shipping_status] = 'not work' if data[:shipping_status].nil?
-        super(data)
       end
     end
   end


### PR DESCRIPTION
### validate_presence_of 함수에 exception을 추가
> app/services/external_channel/base_validator
- 추가 이유
1. 외부 채널에서 데이터를 주지 않으면서 추론이 안되는 데이터가 있다.
validate_presence_of 는 사전에 정의한 데이터들이 nil이 아닌지 검증하는 함수이다. 기존에는 예외 없이 사전에 정의한 모든 데이터에 대해서 nil 검수를 하게 했다. 하지만 실제 데이터 중 주지 않으면서, 계산 할 수 없는 데이터가 있었다. order의 paid_at이 그 예시이다. 이를 대응하기 위해 nullable하게 데이터를 관리하자고 @lucas님과 합의했다. 이에 따라 exception을 추가했다.
2. 아직 주문 상태 등은 리펙토링 전이다.
order_info의 order_status, shipping_status, cancelled_status 들은 아직 리펙토링이 되지 않았다. 추후에 작업될 데이터들 중에도 이러한 사항이 있을 수 있다. 그러한 상황을 유연하게 대응하고자 exception을 추가했다.

### order saver에 shipping_status 추가
> app/services/external_channel/order/saver
external_channel_order_info의 데이터 구조 변경에 따라 saver에 반영했다.