### PR TITLE
쇼피 어댑터 리팩토링

### DIFF
--- a/app/adapters/external_channel/shopee_adapter.rb
+++ b/app/adapters/external_channel/shopee_adapter.rb
@@ -1,34 +1,56 @@
 module ExternalChannel
   class ShopeeAdapter < BaseAdapter
+    public
     attr_reader :base_url
+
+    private
+    attr_reader :key, :default_body, :default_headers
 
     # === 사용 가능한 PRODUCT query property (공식 API 문서 기준이고, 변경될 가능성이 있습니다)
     # === from 과 to 사이 최대 기간은 15일임. 받으려면 15일 간격으로 잘라서 받아야 함.
-    #{
-    #  update_time_from
-    #  update_time_to
-    #  pagination_offset : default 0
-    #  pagination_entries_per_page : default 10, max 100
-    #}
-
+    {
+      # = update_time_from
+      # = update_time_to
+      # = pagination_offset : default 0
+      # = pagination_entries_per_page : default 10, max 100
+    }
 
     # === 사용 가능한 Order query property (공식 API 문서 기준이고, 변경될 가능성이 있습니다)
-    #{
-    #  order_status: ALL/UNPAID/READY_TO_SHIP/COMPLETED/IN_CANCEL/CANCELLED/TO_RETURN, default: ALL
-    #  create_time_from
-    #  create_time_to
-    #  pagination_entries_per_page: default 0
-    #  pagination_offset: default 100, max 100
-    #}
-
-    def initialize
-      @base_url = 'https://partner.shopeemobile.com/api/v1'
-      @shop_id = Rails.application.credentials.dig(:shopee, :api, :shopid)
-      @partner_id = Rails.application.credentials.dig(:shopee, :api, :partner_id)
-      @key = Rails.application.credentials.dig(:shopee, :api, :key)
-    end
+    {
+      # = order_status: ALL/UNPAID/READY_TO_SHIP/COMPLETED/IN_CANCEL/CANCELLED/TO_RETURN, default: ALL
+      # = create_time_from
+      # = create_time_to
+      # = pagination_entries_per_page: default 0
+      # = pagination_offset: default 100, max 100
+    }
 
     public
+    def initialize
+      @base_url = 'https://partner.shopeemobile.com/api/v1'
+      @key = Rails.application.credentials.dig(:shopee, :api, :key)
+
+      shop_id = Rails.application.credentials.dig(:shopee, :api, :shopid)
+      partner_id = Rails.application.credentials.dig(:shopee, :api, :partner_id)
+
+      @default_headers = {
+        'Content-Type': 'application/json'
+      }
+      @default_body = {
+        partner_id: partner_id,
+        shopid: shop_id,
+      }
+      @faraday_options = {
+        request: {
+          timeout: 5,
+          retry: {
+            max: 3,
+            interval: 1
+          }
+        }
+      }
+    end
+
+    # protected
     # == 적절하게 정제된 데이터를 리턴합니다.
     def products(query_hash = {})
       refine_products(call_products(query_hash))
@@ -38,30 +60,29 @@ module ExternalChannel
       refine_orders(call_orders(query_hash))
     end
 
-    protected
-
     def login; end
 
     # == 외부 채널의 API 를 사용하여 각 레코드를 가져옵니다.
     def call_products(query_hash = {})
       endpoint = "#{base_url}/items/get"
-      products_body = set_shopee_body(query_hash)
+      default_body['timestamp'] = Time.now.to_i
 
-      call_list(endpoint, products_body)
+      call_list(endpoint, default_body.merge(query_hash))
         .map{ |data| call_product_by_ids(data['items'].pluck('item_id')) }
-        .flatten
+        .flatten.pluck('item_id')
     end
 
     def call_orders(query_hash = {})
       query_hash[:order_status] ||= 'ALL'
 
       endpoint = "#{base_url}/orders/get"
-      orders_body = set_shopee_body(query_hash)
+      default_body['timestamp'] = Time.now.to_i
 
-      call_list(endpoint, orders_body)
+      call_list(endpoint, default_body.merge(query_hash))
         .map{ |data| call_product_by_ids(data['orders'].pluck('ordersn')) }
         .flatten
     end
+
     # == call_XXX 로 가져온 레코드를 정제합니다.
     def refine_products(products)
       products.map do |product|
@@ -96,10 +117,7 @@ module ExternalChannel
 
     private
 
-    attr_reader :partner_id, :key, :shop_id
-
-    ### === Shoppe에서 데이터를 가져오는 부분
-
+    # === shopee 에서 데이터를 가져오는 부분
     def call_product_by_ids(ids)
       endpoint = "#{base_url}/item/get"
       call_each_by_ids(ids, endpoint, 'item') do |id|
@@ -109,23 +127,23 @@ module ExternalChannel
 
     def call_order_by_sn(sn)
       endpoint = "#{base_url}/orders/detail"
-      # === shopee 에서 받을 수 있는 order의 개수를 50개로 제한함.
+      # === shopee 에서 받을 수 있는 order 의 개수를 50개로 제한함.
       call_each_by_ids(sn.each_slice(50), endpoint, 'orders') do |order_sns|
         { ordersn_list: order_sns }
       end
     end
 
-    # body를 의미하는 block을 받아, 모든 id에 대해 post요청을 보내고 타겟에 대한 묶음을 전달하는 함수.
+    # = body 를 의미하는 block 을 받아, 모든 id에 대해 post 요청을 보내고 타겟에 대한 묶음을 전달하는 함수.
     def call_each_by_ids(ids, endpoint, target)
       ids.map do |id|
-        body = {}
+        default_body['timestamp'] = Time.now.to_i
+
         if block_given?
-          body = yield id
+          default_headers['Authorization'] = make_shopee_signature(endpoint, default_body.merge(yield id))
+          response = request_post(endpoint, default_body.merge(yield id), default_headers)
+
+          response[target]
         end
-        body = set_shopee_body(body)
-        header = get_shopee_header(endpoint, body)
-        response = request_post(endpoint, body, header)
-        response[target]
       end
     end
 
@@ -139,8 +157,8 @@ module ExternalChannel
 
       response_data = []
       while more do
-        header = get_shopee_header(endpoint, body)
-        response = request_post(endpoint, body, header)
+        default_headers['Authorization'] = make_shopee_signature(endpoint, body)
+        response = request_post(endpoint, body, default_headers)
         more = response['more']
         body[:pagination_offset] += body[:pagination_entries_per_page]
 
@@ -148,21 +166,6 @@ module ExternalChannel
       end
 
       response_data
-    end
-
-    def get_shopee_header(endpoint, body)
-      {
-          'Authorization': make_shopee_signature(endpoint, body),
-          'Content-Type': 'application/json'
-      }
-    end
-
-    def set_shopee_body(hash)
-      hash.merge!({
-        partner_id: partner_id,
-        shopid: shop_id,
-        timestamp: (Time.now - 59.minutes).to_i
-      })
     end
 
     def request_post(endpoint, body, header)

--- a/app/adapters/external_channel/shopee_adapter.rb
+++ b/app/adapters/external_channel/shopee_adapter.rb
@@ -1,10 +1,10 @@
 module ExternalChannel
   class ShopeeAdapter < BaseAdapter
     public
-    attr_reader :base_url
+    attr_accessor :base_url
 
     private
-    attr_reader :key, :default_body, :default_headers
+    attr_accessor :key, :default_body, :default_headers
 
     # === 사용 가능한 PRODUCT query property (공식 API 문서 기준이고, 변경될 가능성이 있습니다)
     # === from 과 to 사이 최대 기간은 15일임. 받으려면 15일 간격으로 잘라서 받아야 함.


### PR DESCRIPTION
## 변경점
- make_header / make_body 메소드를 삭제하고, default header와 default body를 사용하도록 수정
- 위의 변경에 대응하여, request에 header와 body를 인자로 넘길 때 커스텀하여 넘기도록 변경
- 변수 'url'을 변수 'endpoint'로 이름 변경
- call_each_by_ids 메소드의 경우, 메소드의 이름에서 명시하고 있듯 id 배열이 요구됨이 자명하여 체크 로직을 생략 
(추가적으로, call_each_by_ids 메소드는 id를 이용해서 해시 키:밸류 쌍을 만들기 위해서 블럭 전달이 강제되는데, 아예 파라미터에 고정시키는게 어떨지 여쭤보고 싶네요)
- call_list 메소드의 경우, 호출하는 부분에서 블럭을 전달하는 기존 방식에서, 반환값을 이용하여 메서드 체인을 사용하도록 수정
- request_post 메소드의 내용 수정, Faraday::Connection에 재시도 옵션 적용