### PR TITLE
버그: adapter와 saver 동작하도록 수정

### DIFF
--- a/app/adapters/external_channel/adapter_factory.rb
+++ b/app/adapters/external_channel/adapter_factory.rb
@@ -1,16 +1,16 @@
 module ExternalChannel
   class AdapterFactory
-    def initialize(channel_name)
-      case channel_name
-      when 'Haravan'
+    def self.get_adapter(channel_name)
+      case channel_name.downcase
+      when 'haravan'
         ExternalChannel::HaravanAdapter.new
-      when 'Tiki'
+      when 'tiki'
         ExternalChannel::TikiAdapter.new
-      when 'Sendo'
+      when 'sendo'
         ExternalChannel::SendoAdapter.new
-      when 'Lazada'
+      when 'lazada'
         ExternalChannel::LazadaAdapter.new
-      when 'Shopee'
+      when 'shopee'
         ExternalChannel::ShopeeAdapter.new
       else
         raise NotImplementedError('Requested Data Is Not Supported!')

--- a/app/adapters/external_channel/base_adapter.rb
+++ b/app/adapters/external_channel/base_adapter.rb
@@ -24,16 +24,20 @@ module ExternalChannel
 
     # == 리퀘스트를 던지는 caller 메소드입니다.
     def request_get(endpoint, params, headers)
-      Faraday.new(endpoint, params) do |conn|
+      Faraday.new(endpoint, params: params) do |conn|
         conn.request(:retry, max: 5, interval: 1, exceptions: ['Timeout::Error'])
 
         return conn.get { |req| req.headers.merge!(headers) }
       end
     end
 
-    def request_post(endpoint, body, headers)
+    def request_post(endpoint, body, headers, default_eception = nil)
+      default_eception ||= [
+        Errno::ETIMEDOUT, 'Timeout::Error',
+        Faraday::TimeoutError, Faraday::RetriableResponse, 'Net::OpenTimeout'
+      ]
       Faraday.new(endpoint) do |conn|
-        conn.request(:retry, max: 5, interval: 1, exceptions: ['Timeout::Error'])
+        conn.request(:retry, max: 5, interval: 1, exceptions: default_eception)
 
         response = conn.post do |req|
           req.headers.merge!(headers)

--- a/app/adapters/external_channel/haravan_adapter.rb
+++ b/app/adapters/external_channel/haravan_adapter.rb
@@ -87,7 +87,7 @@ module ExternalChannel
           title: record['title'],
           channel_name: 'Haravan',
           brand_name: record['vendor'],
-          options: refine_product_options(record)
+          variants: refine_product_options(record)
         }
       end
 

--- a/app/adapters/external_channel/lazada_adapter.rb
+++ b/app/adapters/external_channel/lazada_adapter.rb
@@ -50,6 +50,8 @@ module ExternalChannel
     end
 
     private
+
+    # === TODO:/Users/gomidev/Documents/chromedriver 이 경로로 chrome driver를 깔아줘야 함.
     def get_code
       Selenium::WebDriver::Chrome::Service.driver_path = '/Users/gomidev/Documents/chromedriver'
       options = Selenium::WebDriver::Chrome::Options.new # = 크롬 헤드리스 모드 위해 옵션 설정
@@ -114,8 +116,8 @@ module ExternalChannel
     end
 
     def check_token_validation
-      if token.access_token_expired?
-        if token.refresh_token_expired?
+      if !token.auth_token || token.access_token_expired?
+        if !token.refresh_token || token.refresh_token_expired?
           get_code
         else
           refreshing_token
@@ -175,7 +177,7 @@ module ExternalChannel
             title: record['attributes']['name'],
             channel_name: 'Lazada',
             brand_name: ['attributes']['brand'],
-            options: refine_product_options(record['skus'])
+            variants: refine_product_options(record['skus'])
         }
       end
 

--- a/app/adapters/external_channel/sendo_adapter.rb
+++ b/app/adapters/external_channel/sendo_adapter.rb
@@ -2,7 +2,7 @@ module ExternalChannel
   class SendoAdapter < BaseAdapter
     # Product 요청 파라미터
     # {
-    #   date_form: yyyy/mm/dd string,
+    #   date_from: yyyy/mm/dd string,
     #   date_to: yyyy/mm/dd string,
     #   product_name: string,
     # }
@@ -121,11 +121,15 @@ module ExternalChannel
           id: sales_data["order_number"],
           order_number: sales_data["order_number"],
           billing_amount: sales_data["total_amount_buyer"],
-          variants_ids: sales_details.map {|option| [option["product_variant_id"], option["quantity"]]},
+          variant_ids: sales_details.map {|option| [option["product_variant_id"], option["quantity"]]},
           order_status: map_order_status(sales_data["order_status"]),
-          cancel_status: cancelled_status(sales_data["order_status"]),
+          cancelled_status: cancelled_status(sales_data["order_status"]),
           shipping_status: shipping_status(sales_data["order_status"]),
-          pay_method: map_pay_method(sales_data["payment_method"])
+          pay_method: map_pay_method(sales_data["payment_method"]),
+          paid_at: nil,
+          channel: 'sendo',
+          ordered_at: Time.now.utc.to_formatted_s(sales_data['order_date_time_stamp']),
+          ship_fee: sales_data['total_amount_buyer'] - sales_data['total_amount']
         }
       end
     end

--- a/app/adapters/external_channel/tiki_adapter.rb
+++ b/app/adapters/external_channel/tiki_adapter.rb
@@ -90,7 +90,7 @@ module ExternalChannel
           title: record['name'],
           channel_name: 'Tiki',
           brand_name: call_product(record['product_id'])['attributes']['brand']['value'],
-          options: [
+          variants: [
             {
               id: record['product_id'],
               price: record['price'].to_i,

--- a/app/services/external_channel/base_manager.rb
+++ b/app/services/external_channel/base_manager.rb
@@ -7,8 +7,8 @@ module ExternalChannel
       @adapter = channel_adapter
     end
 
-    def save_all
-      list = adapter.get_list(data_type)
+    def save_all(query_hash = {})
+      list = adapter.get_list(data_type, query_hash)
       saver.save_all(list) if validator.valid_all?(list)
     end
 

--- a/app/services/external_channel/manager_factory.rb
+++ b/app/services/external_channel/manager_factory.rb
@@ -1,6 +1,6 @@
 module ExternalChannel
   class ManagerFactory
-    def self.initialize(data_type, adapter)
+    def self.get_manager(data_type, adapter)
       case data_type
       when 'product'
         ExternalChannel::Product::Manager.new(adapter)


### PR DESCRIPTION
## adapter_factory
1. 클래스 메소드로 함수를 선언
2. 대소문자 차이로 구분이 안되는 문제 해결

## faraday gem default exception 추가
1. faraday의 conn.eception 보니까 기본 exception이 우리 것 보다 에러 커버범위가 넓어서 해당 로직 추가

## adapter 데이터 차이가 있는 부분 해결
1. haravan, tiki, lazada
product option의 데이터 명을 options->variants로 수정
2. lazada
최초 생성시 토큰이 없는 경우에 에러나는 부분 해결
3. sendo
빠진 데이터 추가
4. shopee
데이터가 잘못들어간 것들 수정
## manager의 save_all 로직에서 query hash 입력
- 기존에는 없어서 추가

## manager factory의 함수 명 변경
initialize는 객체 생성할때도 불릴 것 같아서 이름을 변경함.