### PR TITLE
핫픽스: 업체 데코레이터 메소드의 오류 수정

### DIFF
--- a/app/decorators/companies/with_brand_country_decorator.rb
+++ b/app/decorators/companies/with_brand_country_decorator.rb
@@ -5,11 +5,7 @@ module Companies
     data_key :countries
 
     def countries
-      if super.count > 1
-        Countries::DefaultDecorator.decorate_collection(super)
-      else
-        Countries::DefaultDecorator.decorate(super)
-      end
+      Countries::DefaultDecorator.decorate(super)
     end
   end
 end

--- a/app/decorators/companies/with_country_decorator.rb
+++ b/app/decorators/companies/with_country_decorator.rb
@@ -4,11 +4,7 @@ module Companies
     data_key :countries
 
     def countries
-      if super.count > 1
-        Countries::DefaultDecorator.decorate_collection(super)
-      else
-        Countries::DefaultDecorator.decorate(super)
-      end
+      Countries::DefaultDecorator.decorate(super)
     end
   end
 end


### PR DESCRIPTION
draper 젬에서 제공하는 decorate 메소드는 배열을 파라미터로 받지 못합니다..