### PR TITLE
기능: 라자다 어댑터에 paid_at을 적용, 주문 validator 임시 해제(스키마 변경이 잦기 때문) (#185)

### DIFF
--- a/app/services/external_channel/order/validator.rb
+++ b/app/services/external_channel/order/validator.rb
@@ -7,13 +7,15 @@ module ExternalChannel
       end
 
       def valid_all?(orders)
-        orders.all? do |order|
-          valid? order
-        end
+        true
+        
+        # orders.all? do |order|
+        #   valid? order
+        # end
       end
 
       def valid?(order)
-        validate_presence_of(order, %i[paid_at cancelled_status shipping_status])
+        validate_presence_of(order, %i[paid_at cancelled_status shipping_status tracking_company_code confirmed_status source_name delivered_at])
         only_allowed?(order)
       end
     end


### PR DESCRIPTION
* 수정: lazada 주문의 paid_at 데이터를 추적

* 수정: 라자다 어댑터에서 채널 검색 시에 국가 정보도 함께 검색하도록 수정

* 수정: 라자다 어댑터의 채널 검색 쿼리 수정

* 수정: 라자다 어댑터의 결제 시간 데이터 타입 추가

* 수정: 결제시간이 없는 경우를 대비한 조건식 추가

* 수정: 데이터 검증 로직 업데이트

* 수정: 주문 데이터의 스키마 수정이 잦아 저장하는 데이터를 통제하는 부분을 제거

* 수정: 주문 데이터의 스키마 수정이 잦아 저장하는 데이터를 통제하는 부분을 제거