### PR TITLE
핫픽스: STORE-1066/product item 삭제시 collection에서 발생하는 버그 수정

### DIFF
--- a/app/models/product_collection.rb
+++ b/app/models/product_collection.rb
@@ -5,6 +5,7 @@
 #  id                         :bigint           not null, primary key
 #  active                     :boolean          default(FALSE), not null
 #  cost_price                 :integer          default(0), not null
+#  deleted_at                 :datetime
 #  gomi_standard_product_code :string(255)      not null
 #  name                       :string(255)
 #  selling_price              :integer          default(0), not null
@@ -15,6 +16,7 @@
 # Indexes
 #
 #  index_product_collections_on_country_id                  (country_id)
+#  index_product_collections_on_deleted_at                  (deleted_at)
 #  index_product_collections_on_gomi_standard_product_code  (gomi_standard_product_code) UNIQUE
 #
 # Foreign Keys
@@ -23,6 +25,7 @@
 #
 class ProductCollection < NationRecord
   include UseGomiStandardProductCode
+  acts_as_paranoid
 
   has_many :elements, class_name: 'ProductCollectionElement'
   has_many :items, class_name: 'ProductItem', through: :elements, source: :product_item

--- a/app/models/product_collection_element.rb
+++ b/app/models/product_collection_element.rb
@@ -4,6 +4,7 @@
 #
 #  id                    :bigint           not null, primary key
 #  amount                :integer
+#  deleted_at            :datetime
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  product_collection_id :bigint           not null
@@ -11,6 +12,7 @@
 #
 # Indexes
 #
+#  index_product_collection_elements_on_deleted_at             (deleted_at)
 #  index_product_collection_elements_on_product_collection_id  (product_collection_id)
 #  index_product_collection_elements_on_product_item_id        (product_item_id)
 #
@@ -20,6 +22,8 @@
 #  fk_rails_...  (product_item_id => product_items.id)
 #
 class ProductCollectionElement < ApplicationRecord
+  acts_as_paranoid
+
   belongs_to :product_item
   belongs_to :collection, class_name: 'ProductCollection', foreign_key: :product_collection_id
 

--- a/db/migrate/product_collection/20210408064103_add_deleted_at_to_product_collection_and_element.rb
+++ b/db/migrate/product_collection/20210408064103_add_deleted_at_to_product_collection_and_element.rb
@@ -1,0 +1,15 @@
+class AddDeletedAtToProductCollectionAndElement < ActiveRecord::Migration[6.0]
+  def up
+    add_column :product_collections, :deleted_at, :datetime
+    add_index :product_collections, :deleted_at
+    add_column :product_collection_elements, :deleted_at, :datetime
+    add_index :product_collection_elements, :deleted_at
+  end
+
+  def down
+    remove_index :product_collections, :deleted_at
+    remove_column :product_collections, :deleted_at, :datetime
+    remove_index :product_collection_elements, :deleted_at
+    remove_column :product_collection_elements, :deleted_at, :datetime
+  end
+end


### PR DESCRIPTION
# 작업 배경 및 목적 3줄 요약 (Background and Purpose in 3 line)
- product item에 soft deletion이 적용되었으나, collection과의 관계에서 버그가 발생했습니다.

# 작업 내용(Content)
- collection까지 연결되는 record에 soft deletion을 적용합니다.

# 링크(Link)
- https://github.com/gomicorp/GomiStore/pull/712
- https://gomicorp.atlassian.net/browse/STORE-1066

# 희망 리뷰 완료 일(Expected due date)
`2021. 4. 8. 목`
