### PR TITLE
기능: STORE-1283/ jp국가 생성 및 코드 확장

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -27,8 +27,12 @@ class Country < ApplicationRecord
     @vn ||= find_by(short_name: 'vn')
   end
 
-  def self.ko
-    @ko ||= find_by(short_name: 'ko')
+  def self.kr
+    @kr ||= find_by(short_name: 'kr')
+  end
+
+  def self.jp
+    @jp ||= find_by(short_name: 'jp')
   end
 
   def self.undef
@@ -57,7 +61,8 @@ class Country < ApplicationRecord
     [
       { name: 'vietnam', name_ko: '베트남', locale: 'vi', short_name: 'vn', iso_code: 'VND' },
       { name: 'thailand', name_ko: '태국', locale: 'th', short_name: 'th', iso_code: 'THB' },
-      { name: 'korea', name_ko: '한국', locale: 'ko', short_name: 'ko', iso_code: 'KRW' }
+      { name: 'korea', name_ko: '한국', locale: 'ko', short_name: 'kr', iso_code: 'KRW' },
+      { name: 'japan', name_ko: '일본', locale: 'ja', short_name: 'jp', iso_code: 'JPY' }
     ]
   end
 end

--- a/app/models/external_channel/order_info.rb
+++ b/app/models/external_channel/order_info.rb
@@ -27,11 +27,13 @@
 #
 # Indexes
 #
-#  ex_order_info_channel                             (channel)
-#  ex_order_info_ex_o_id                             (external_channel_order_id)
-#  ex_order_info_o_id_c_id                           (external_channel_order_id,country_id)
-#  ex_order_info_o_id_channel                        (external_channel_order_id,channel)
-#  index_external_channel_order_infos_on_country_id  (country_id)
+#  ex_order_info_channel                                            (channel)
+#  ex_order_info_ex_o_id                                            (external_channel_order_id)
+#  ex_order_info_o_id_c_id                                          (external_channel_order_id,country_id)
+#  ex_order_info_o_id_channel                                       (external_channel_order_id,channel)
+#  index_external_channel_order_infos_on_channel                    (channel)
+#  index_external_channel_order_infos_on_country_id                 (country_id)
+#  index_external_channel_order_infos_on_external_channel_order_id  (external_channel_order_id)
 #
 # Foreign Keys
 #

--- a/app/models/nation_record.rb
+++ b/app/models/nation_record.rb
@@ -5,6 +5,8 @@ class NationRecord < ApplicationRecord
 
   scope :th, -> { unscoped.includes(:country).where(country: Country.th) }
   scope :vn, -> { unscoped.includes(:country).where(country: Country.vn) }
+  scope :kr, -> { unscoped.includes(:country).where(country: Country.kr) }
+  scope :jp, -> { unscoped.includes(:country).where(country: Country.jp) }
   scope :undef, -> { unscoped.includes(:country).where(country: Country.undef) }
   scope :at, ->(key) { unscoped.includes(:country).where(country: Country.at(key)) }
   scope :global, -> { unscoped.includes(:country).where(country: Country.all) }

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -4,7 +4,7 @@
 #
 #  id                    :bigint           not null, primary key
 #  amount                :integer
-#  cancel_message        :text(65535)
+#  cancel_message        :text(16777215)
 #  cancelled             :boolean          default(FALSE), not null
 #  delivery_amount       :integer
 #  expire_at             :datetime

--- a/app/services/external_channel/product/saver.rb
+++ b/app/services/external_channel/product/saver.rb
@@ -107,7 +107,6 @@ module ExternalChannel
         no_brand = Brand.find_or_initialize_by(subtitle: NO_BRAND_NAME, company: temp_company)
         return no_brand unless no_brand.new_record?
 
-        # TODO: 지금 이름이 vn이랑 vi랑 섞여서 기록되어 있다. 확인이 필요하다.
         # 이름이 없으면 만들어 줌
         brand_title = { en: NO_BRAND_NAME, ko: NO_BRAND_NAME }
         brand_title[Country.send(ApplicationRecord.country_code).locale] = NO_BRAND_NAME

--- a/app/services/haravan/api_service.rb
+++ b/app/services/haravan/api_service.rb
@@ -123,7 +123,7 @@ module Haravan
         @product = ::Product.find_or_initialize_by(haravan_id: @product_id)
         @product.assign_attributes(brand_id: @brand.id,
                                    running_status: 'pending',
-                                   title: {'vn': @title, 'en': @title, 'ko': @title},
+                                   title: {'vi': @title, 'en': @title, 'ko': @title},
                                    country: Country.vn)
         # @product.assign_attributes(title: product_data["title"].to_h)
         @product.save!

--- a/app/services/store/paying/charge.rb
+++ b/app/services/store/paying/charge.rb
@@ -19,7 +19,7 @@ module Store
           # 결제완료 : paid
           # 결제취소 : cancelled
           # 결제실패 : failed
-          ko: {
+          kr: {
             ready: :progress,
             paid: :done,
             cancelled: :revert,
@@ -36,7 +36,7 @@ module Store
         charge_id = case @current_country
                     when :th
                       charge_info.id
-                    when :ko
+                    when :kr
                       charge_info.dig('merchant_uid')
                     else
                       nil

--- a/app/services/store/paying/pg_payment.rb
+++ b/app/services/store/paying/pg_payment.rb
@@ -32,7 +32,7 @@ module Store
           amount: checkout_amount,
           # 결제 유저가 결제를 마친 뒤 플랫폼으로 돌아올 uri입니다. for omise_th
           return_uri: return_uri,
-          # 결제 선등록에서 사용할 charge_id입니다. for iamport_ko
+          # 결제 선등록에서 사용할 charge_id입니다. for iamport_kr
           charge_id: gen_charge_id(order.payment)
         )
       end
@@ -74,7 +74,7 @@ module Store
         @pg ||= case ENV['APP_COUNTRY']
                 when 'th'
                   Paying::ThaiPg.new(params: params)
-                when 'ko'
+                when 'kr'
                   Paying::KoreaPg.new(params: params)
                 end
       end

--- a/db/data/20210429060041_set_initial_data_for_shipping_fee_policy.rb
+++ b/db/data/20210429060041_set_initial_data_for_shipping_fee_policy.rb
@@ -33,7 +33,7 @@ class SetInitialDataForShippingFeePolicy < ActiveRecord::Migration[6.0]
         {feature: '-', fee: 0}
       ]
     },
-    ko: {
+    kr: {
       normal: [
         {feature: '-', fee: 3000, default: true}
       ],

--- a/db/data/20210429102919_link_fee_policy_to_ship_info.rb
+++ b/db/data/20210429102919_link_fee_policy_to_ship_info.rb
@@ -10,7 +10,7 @@ class LinkFeePolicyToShipInfo < ActiveRecord::Migration[6.0]
       far: ['normal', 'suburb'],
       free: ['free', '-']
     },
-    ko: {
+    kr: {
       normal: ['normal', '-'],
       free: ['free', '-']
     }

--- a/db/data/20210520024525_add_country_for_japan.rb
+++ b/db/data/20210520024525_add_country_for_japan.rb
@@ -1,0 +1,11 @@
+class AddCountryForJapan < ActiveRecord::Migration[6.0]
+  def up
+    Country.find_or_create_by(name: 'japan', name_ko: '일본', locale: 'ja', short_name: 'jp', iso_code: 'JPY')
+    Country.find_by_name('korea').update(short_name: 'kr')
+  end
+
+  def down
+    Country.find_by_name(name: 'japan').delete
+    Country.find_by_name('korea').update(short_name: 'ko')
+  end
+end

--- a/db/seed/country.rb
+++ b/db/seed/country.rb
@@ -1,3 +1,4 @@
 Country.find_or_create_by(name: 'thailand', name_ko: '태국', locale: 'th', short_name: 'th', iso_code: 'THB')
 Country.find_or_create_by(name: 'vietnam', name_ko: '베트남', locale: 'vi', short_name: 'vn', iso_code: 'VND')
-Country.find_or_create_by(name: 'korea', name_ko: '한국', locale: 'ko', short_name: 'ko', iso_code: 'KRW')
+Country.find_or_create_by(name: 'korea', name_ko: '한국', locale: 'ko', short_name: 'kr', iso_code: 'KRW')
+Country.find_or_create_by(name: 'japan', name_ko: '일본', locale: 'ja', short_name: 'jp', iso_code: 'JPY')

--- a/test/fixtures/external_channel_order_infos.yml
+++ b/test/fixtures/external_channel_order_infos.yml
@@ -27,11 +27,13 @@
 #
 # Indexes
 #
-#  ex_order_info_channel                             (channel)
-#  ex_order_info_ex_o_id                             (external_channel_order_id)
-#  ex_order_info_o_id_c_id                           (external_channel_order_id,country_id)
-#  ex_order_info_o_id_channel                        (external_channel_order_id,channel)
-#  index_external_channel_order_infos_on_country_id  (country_id)
+#  ex_order_info_channel                                            (channel)
+#  ex_order_info_ex_o_id                                            (external_channel_order_id)
+#  ex_order_info_o_id_c_id                                          (external_channel_order_id,country_id)
+#  ex_order_info_o_id_channel                                       (external_channel_order_id,channel)
+#  index_external_channel_order_infos_on_channel                    (channel)
+#  index_external_channel_order_infos_on_country_id                 (country_id)
+#  index_external_channel_order_infos_on_external_channel_order_id  (external_channel_order_id)
 #
 # Foreign Keys
 #

--- a/test/models/external_channel/order_info_test.rb
+++ b/test/models/external_channel/order_info_test.rb
@@ -27,11 +27,13 @@
 #
 # Indexes
 #
-#  ex_order_info_channel                             (channel)
-#  ex_order_info_ex_o_id                             (external_channel_order_id)
-#  ex_order_info_o_id_c_id                           (external_channel_order_id,country_id)
-#  ex_order_info_o_id_channel                        (external_channel_order_id,channel)
-#  index_external_channel_order_infos_on_country_id  (country_id)
+#  ex_order_info_channel                                            (channel)
+#  ex_order_info_ex_o_id                                            (external_channel_order_id)
+#  ex_order_info_o_id_c_id                                          (external_channel_order_id,country_id)
+#  ex_order_info_o_id_channel                                       (external_channel_order_id,channel)
+#  index_external_channel_order_infos_on_channel                    (channel)
+#  index_external_channel_order_infos_on_country_id                 (country_id)
+#  index_external_channel_order_infos_on_external_channel_order_id  (external_channel_order_id)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
# 작업 배경 및 목적 3줄 요약 (Background and Purpose in 3 line)
- 일본 쿠마몰 런칭에 따라 한국에서 백오피스를 함께 운영해야 합니다.
- 이를 위해 국가 레코드에 일본을 추가하고 그에 따라 코드 전반을 수정합니다.

# 링크(Link)
- https://gomicorp.atlassian.net/browse/STORE-1283

# 기타 사항(Etc)
- 새로운 국가 코드 추가는 Ecommerce API의 데이터 마이그레이션을 통해 이루어집니다.
