### PR TITLE
[feat][STORE-1431] Payment 하위에 Charge 모델 추가

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -46,7 +46,7 @@ class Payment < NationRecord
     vn_pay
   ].freeze
 
-  PAY_METHOD_VIA_PG =%i[
+  PAY_METHOD_VIA_PG = %i[
     omise
     iamport
     momo_pay

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -26,7 +26,7 @@
 #
 #  fk_rails_...  (order_info_id => order_infos.id)
 #
-class Payment < ApplicationRecord
+class Payment < NationRecord
 
   STATUS = %w[
     pay_wait
@@ -36,6 +36,22 @@ class Payment < ApplicationRecord
     refund_reject
   ].freeze
   act_as_status_loggable status_list: STATUS.to_echo
+
+  PAY_METHOD = %i[
+    bank
+    cod
+    omise
+    iamport
+    momo_pay
+    vn_pay
+  ].freeze
+
+  PAY_METHOD_VIA_PG =%i[
+    omise
+    iamport
+    momo_pay
+    vn_pay
+  ]
 
   extend_has_many_attached :pay_slips
   belongs_to :order_info

--- a/app/models/payment/charge.rb
+++ b/app/models/payment/charge.rb
@@ -1,0 +1,8 @@
+class Payment::Charge < NationRecord
+  belongs_to :payment
+
+  def supplement
+    JSON.parse self[:supplement] if self[:supplement]
+  end
+
+end

--- a/db/data/20210610025720_set_country_for_payment.rb
+++ b/db/data/20210610025720_set_country_for_payment.rb
@@ -1,0 +1,11 @@
+class SetCountryForPayment < ActiveRecord::Migration[6.0]
+  def up
+    Payment.all.each do |payment|
+      payment.update(country: payment.order_info.country)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20210610028057_redefine_pay_method_for_payment.rb
+++ b/db/data/20210610028057_redefine_pay_method_for_payment.rb
@@ -1,0 +1,9 @@
+class RedefinePayMethodForPayment < ActiveRecord::Migration[6.0]
+  def up
+    Payment.where(pay_method: 'card').update_all(pay_method: :omise, updated_at: DateTime.now)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20210610045910_set_charge_for_current_payment.rb
+++ b/db/data/20210610045910_set_charge_for_current_payment.rb
@@ -1,0 +1,11 @@
+class SetChargeForCurrentPayment < ActiveRecord::Migration[6.0]
+  def up
+    Payment.where.not(charge_id: [nil, 0]).each do |payment|
+      Payment::Charge.create(payment: payment, pg_name: payment.pay_method, pg_id: payment.charge_id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20210610025604_add_country_for_payment.rb
+++ b/db/migrate/20210610025604_add_country_for_payment.rb
@@ -1,0 +1,5 @@
+class AddCountryForPayment < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :payments, :country, foreign_key: true
+  end
+end

--- a/db/migrate/20210610030630_create_payment_charges.rb
+++ b/db/migrate/20210610030630_create_payment_charges.rb
@@ -1,0 +1,13 @@
+class CreatePaymentCharges < ActiveRecord::Migration[6.0]
+  def change
+    create_table :payment_charges do |t|
+      t.string :pg_name, null: false
+      t.string :pg_id
+      t.string :supplement
+      t.references :payment, foreign_key: true
+      t.references :country, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/models/payment/charge_spec.rb
+++ b/spec/models/payment/charge_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Payment::Charge, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
기존에는 PG의 결제 정보를, key를 통해 필요시마다 api로 얻어왔었습니다.
그러나 다른 PG 연동을 확장함에 따라, api를 상시 제공 하지 않고, event 발생 전후에만 데이터를 보내주는 PG들도 대응할 필요가 있었습니다. 따라서, 필요시에 접근할 수 있도록 모델을 만들어 해당 리소스를 저장해야 합니다.

이를 위해,
1. payment를 country구분하였습니다. [STORE-1379]
2. payment의 속성인 pay method의 card 항목을 pg로 세분화 했습니다. [STORE-1378]
3. payment 하위에 charge 모델을 만들었습니다.[STORE-1431]
3-1. charge 모델은, 여러 pg의 response에 유연하게 대응하기 위하여, charge를 식별할 수 있는 필수 정보만을 컬럼으로 갖고, 디테일한 내용은 supplement 컬럼에 json 형태로 저장합니다.

[STORE-1379]: https://gomicorp.atlassian.net/browse/STORE-1379
[STORE-1378]: https://gomicorp.atlassian.net/browse/STORE-1378
[STORE-1431]: https://gomicorp.atlassian.net/browse/STORE-1431